### PR TITLE
Only if the user is not root, do we need sudo

### DIFF
--- a/lib/mccloud/provisioner/chef_solo.rb
+++ b/lib/mccloud/provisioner/chef_solo.rb
@@ -44,11 +44,11 @@ module Mccloud
         
         puts "Running chef-solo"
         options={ :port => 22, :keys => [ vm.private_key ], :paranoid => false, :keys_only => true}
-        if vm.user=="root"
-          Mccloud::Util.ssh(vm.instance.public_ip_address,vm.user,options,"sudo chef-solo -c /tmp/solo.rb -j /tmp/dna.json -l debug")
-        else
-          Mccloud::Util.ssh(vm.instance.public_ip_address,vm.user,options,"chef-solo -c /tmp/solo.rb -j /tmp/dna.json -l debug")
-        end
+        Mccloud::Util.ssh(vm.instance.public_ip_address,
+                          vm.user,
+                          options,
+                          vm.user == "root" ? "":"sudo " +
+                          "chef-solo -c /tmp/solo.rb -j /tmp/dna.json -l debug")
       end
       # Returns the run list for the provisioning
       def run_list


### PR DESCRIPTION
This wasn't working on ubuntu with the default ubuntu user (not root).  I updated the logic to use sudo for anybody but root.  Another option would be to always use sudo because it doesn't hurt anything if you are already root.
