### PR TITLE
Chef Omnibus Installer Bootstrap Script

### DIFF
--- a/lib/mccloud/templates/bootstrap/bootstrap-chef-omnibus.sh
+++ b/lib/mccloud/templates/bootstrap/bootstrap-chef-omnibus.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -ex
+
+# download omnibus install.sh
+if which curl 2>/dev/null; then
+    curl -L http://opscode.com/chef/install.sh | sudo bash
+else
+    wget -q -O - http://opscode.com/chef/install.sh | sudo bash
+fi


### PR DESCRIPTION
This is the most simple omnibus installer I could come up with. Note that it is Chef only (i.e. no Puppet). Works with either `wget` or `curl`, whatever is present.

Fixes GH-23 from my point of view.
