### PR TITLE
GH-26: relax thor version constraint

### DIFF
--- a/mccloud.gemspec
+++ b/mccloud.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   #s.add_dependency "templater"
   s.add_dependency "popen4", "~> 0.1.2"
-  s.add_dependency "thor", "~> 0.14.6"
+  s.add_dependency "thor", ">= 0.14.6"
   s.add_dependency "highline", "~> 1.6.1"
   #s.add_dependency "progressbar"
   #s.add_development_dependency "cucumber", "0.8.5"


### PR DESCRIPTION
relax thor version to `>= 0.14.6` for compatibility with other gems requiring thor ~> 0.16.0.
