### PR TITLE
fix validation error thrown by net/ssh by symbolizing the keys of the ss...

### DIFF
--- a/lib/mccloud/provider/aws/vm/scp.rb
+++ b/lib/mccloud/provider/aws/vm/scp.rb
@@ -6,16 +6,25 @@ module Mccloud::Provider
         scp(src,dest,options)
       end
 
-       def scp(local_path, remote_path, scp_options = {})
-         unless File.exists?(local_path)
+      def scp(local_path, remote_path, scp_options = {})
+        unless File.exists?(local_path)
           raise Mccloud::Error,"scp failed: #{local_path} does not exist"
-         end
-         #@raw.scp(src,dest)
-         scp_options[:key_data] = [@raw.private_key] if @raw.private_key
+        end
 
-         ::Fog::SCP.new(self.ip_address, @raw.username, scp_options).upload(local_path, remote_path, {})
+        #@raw.scp(src,dest)
+        scp_options[:key_data] = [@raw.private_key] if @raw.private_key
+
+        ::Fog::SCP.new(self.ip_address, @raw.username, sanitize(scp_options)).upload(local_path, remote_path, {})
       end
 
-       end #module
-      end #module
+      #
+      # sanitize the options by converting to a hash with
+      # all keys converted to symbols as required by net/ssh
+      #
+      def sanitize(options)
+        Hash[options.map{|(k,v)| [k.to_sym,v]}]
+      end
+
     end #module
+  end #module
+end #module


### PR DESCRIPTION
...h_options hash

This one fixes issue #33

Apart from sanitizing the `ssh_options` hash I corrected the indentation, that's why the diff looks a bit weird
