### PR TITLE
Add support for encrypted data bags

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ You can use multiple provisioners per vm
     roles_path
     provisioning_path
     data_bags_path
+    encrypted_data_bag_secret_key_path
     json
     json_erb
     clean_after_run
@@ -395,6 +396,7 @@ You can use multiple provisioners per vm
           chef.cookbooks_path = [ "cookbooks", "site-cookbooks" ]
           chef.roles_path = "roles"
           chef.data_bags_path = "data_bags"
+          chef.encrypted_data_bag_secret_key_path = "my_databag_secret"
           chef.clean_after_run = false
 
           chef.json.merge!(n.default_attrs)

--- a/lib/mccloud/provider/core/vm.rb
+++ b/lib/mccloud/provider/core/vm.rb
@@ -51,6 +51,7 @@ module Mccloud
 
       attr_accessor :forwardings
       attr_accessor :shared_folders
+      attr_accessor :shared_files
       attr_accessor :stacked
       attr_accessor :declared
 
@@ -58,6 +59,7 @@ module Mccloud
         @env=env
         @forwardings=Array.new
         @shared_folders = Array.new
+        @shared_files = Array.new
         @stacked=false
         @auto_selection=true
         @declared=true

--- a/lib/mccloud/provider/core/vm/rsync.rb
+++ b/lib/mccloud/provider/core/vm/rsync.rb
@@ -7,11 +7,21 @@ module Mccloud::Provider
         @shared_folders << { :name => name, :dest => dest, :src => src, :options => new_options}
       end
 
+      def share_file(name , dest,src,options={})
+        new_options={:mute => false}.merge(options)
+        @shared_files << { :name => name, :dest => dest, :src => src, :options => new_options}
+      end
+
       def share
         @shared_folders.each do |folder|
           self.execute("test -d '#{folder[:dest]}' || mkdir -p '#{folder[:dest]}' ")
           clean_src_path=File.join(Pathname.new(folder[:src]).expand_path.cleanpath.to_s,'/')
           rsync(clean_src_path,folder[:dest],folder[:options])
+        end
+        @shared_files.each do |file|
+          self.execute("test -d '#{File.dirname(file[:dest])}' || mkdir -p '#{File.dirname(file[:dest])}' ")
+          clean_src_path=Pathname.new(file[:src]).expand_path.cleanpath.to_s
+          rsync(clean_src_path,file[:dest],file[:options])
         end
       end
 

--- a/lib/mccloud/provisioner/chef_solo.rb
+++ b/lib/mccloud/provisioner/chef_solo.rb
@@ -20,6 +20,7 @@ module Mccloud
       attr_accessor :roles_path
       attr_accessor :provisioning_path
       attr_accessor :data_bags_path
+      attr_accessor :encrypted_data_bag_secret_key_path
       attr_accessor :json
       attr_accessor :json_erb
       attr_accessor :clean_after_run
@@ -96,6 +97,7 @@ module Mccloud
         configfile << "log_level #{log_level}"
         configfile << "role_path \"/tmp/#{File.basename(roles_path)}\"" unless roles_path.nil?
         configfile << "data_bag_path \"/tmp/#{File.basename(data_bags_path)}\"" unless data_bags_path.nil?
+        configfile << "encrypted_data_bag_secret \"/tmp/#{File.basename(encrypted_data_bag_secret_key_path)}\"" unless encrypted_data_bag_secret_key_path.nil?
 
         #convert string to Tempfile (instead of StringIO), as server.transfer expects a file with a filename
         temp_file_json = Tempfile.new("dna_json")
@@ -122,6 +124,10 @@ module Mccloud
 
         unless data_bags_path.nil?
           server.share_folder("databags_path","/tmp/" + File.basename(data_bags_path),data_bags_path,{:mute => true})
+        end
+
+        unless encrypted_data_bag_secret_key_path.nil?
+          server.share_file("encrypted_databag_secret","/tmp/" + File.basename(encrypted_data_bag_secret_key_path),encrypted_data_bag_secret_key_path,{:mute => true})
         end
 
         server.share
@@ -156,6 +162,11 @@ module Mccloud
             unless data_bags_path.nil?
                 env.ui.info "[#{server.name}] - [#{@name}] - Cleaning data_bags_path #{data_bags_path}"
                 server.execute("rm -rf /tmp/#{File.basename(data_bags_path)}",{:mute => true})
+            end
+
+            unless encrypted_data_bag_secret_key_path.nil?
+                env.ui.info "[#{server.name}] - [#{@name}] - Cleaning encrypted_databag_secret #{encrypted_data_bag_secret_key_path}"
+                server.execute("rm -rf /tmp/#{File.basename(encrypted_data_bag_secret_key_path)}",{:mute => true})
             end
           end
         end
@@ -240,6 +251,7 @@ module Mccloud
           :recipe_url => config.recipe_url,
           :roles_path => roles_path,
           :data_bags_path => data_bags_path,
+          :encrypted_data_bag_secret_key_path => encrypted_data_bag_secret_key_path
         })
       end
       def run_chef_solo


### PR DESCRIPTION
This PR adds support for encrypted data bags by:
- adding `encrypted_data_bag_secret_key_path` to the chef config (pretty long name but it's consisten with Vagrant)
- rsyncing encrypted data bag key as a single file
- add the `encrypted_data_bag_secret` to the generated solo.rb
- updated README with example usage
